### PR TITLE
feat: add force flag to document deletion

### DIFF
--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -399,8 +399,13 @@ func (c *Client) GetDocument(ctx context.Context, name string) (*genai.Document,
 	return c.client.FileSearchStores.Documents.Get(ctx, name, nil)
 }
 
-func (c *Client) DeleteDocument(ctx context.Context, name string) error {
-	return c.client.FileSearchStores.Documents.Delete(ctx, name, nil)
+func (c *Client) DeleteDocument(ctx context.Context, name string, force bool) error {
+	cfg := &genai.DeleteDocumentConfig{}
+	if force {
+		cfg.Force = new(bool)
+		*cfg.Force = true
+	}
+	return c.client.FileSearchStores.Documents.Delete(ctx, name, cfg)
 }
 
 func (c *Client) DeleteFile(ctx context.Context, name string) error {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -25,7 +25,7 @@ type MockGeminiClient struct {
 	UploadFileFunc          func(ctx context.Context, path string, opts *gemini.UploadFileOptions) (*genai.File, error)
 	DeleteFileFunc          func(ctx context.Context, name string) error
 	ResolveDocumentNameFunc func(ctx context.Context, storeNameOrID, docNameOrID string) (string, error)
-	DeleteDocumentFunc      func(ctx context.Context, name string) error
+	DeleteDocumentFunc      func(ctx context.Context, name string, force bool) error
 	CloseFunc               func()
 }
 
@@ -65,8 +65,8 @@ func (m *MockGeminiClient) DeleteFile(ctx context.Context, name string) error {
 func (m *MockGeminiClient) ResolveDocumentName(ctx context.Context, storeNameOrID, docNameOrID string) (string, error) {
 	return m.ResolveDocumentNameFunc(ctx, storeNameOrID, docNameOrID)
 }
-func (m *MockGeminiClient) DeleteDocument(ctx context.Context, name string) error {
-	return m.DeleteDocumentFunc(ctx, name)
+func (m *MockGeminiClient) DeleteDocument(ctx context.Context, name string, force bool) error {
+	return m.DeleteDocumentFunc(ctx, name, force)
 }
 func (m *MockGeminiClient) Close() {
 	if m.CloseFunc != nil {

--- a/main.go
+++ b/main.go
@@ -704,6 +704,7 @@ func main() {
 
 	var docDelStore string
 	var docDelStoreID string
+	var docDelForce bool
 	docDelCmd := &cobra.Command{
 		Use:     "delete [name]",
 		Aliases: []string{"rm", "del"},
@@ -740,7 +741,7 @@ func main() {
 				}
 			}
 
-			err = client.DeleteDocument(ctx, docID)
+			err = client.DeleteDocument(ctx, docID, docDelForce)
 			if err != nil {
 				return err
 			}
@@ -753,6 +754,7 @@ func main() {
 	}
 	docDelCmd.Flags().StringVar(&docDelStore, "store", "", "Store display name (optional, for name resolution)")
 	docDelCmd.Flags().StringVar(&docDelStoreID, "store-id", "", "Store resource ID (optional, for name resolution)")
+	docDelCmd.Flags().BoolVar(&docDelForce, "force", false, "Force delete even if document contains chunks")
 	docDelCmd.RegisterFlagCompletionFunc("store", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return getCompleter().GetStoreNames(), cobra.ShellCompDirectiveNoFileComp
 	})


### PR DESCRIPTION
- Adds --force flag to file-search doc delete command to allow deleting non-empty documents.

- Updates GeminiClient interface and implementation to support force deletion.

- Updates MCP server delete_document tool to support force parameter.

- Updates tests to match new interface.