### PR TITLE
docs: add note that importing from Files API does not preserve file name

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,8 +41,10 @@ This MCP server provides 10 tools for interacting with Gemini File Search. By de
 
 ### Core Tools (Recommended)
 - **`query_knowledge_base`** - Query the knowledge base with optional metadata filtering
-- **`import_file_to_store`** - Import files from Files API into a store
 - **`upload_file`** - Upload and index files directly to a store
+
+### Advanced Tools
+- **`import_file_to_store`** - Import files from Files API into a store. **Note:** The API cannot currently preserve the display name of the file when using this method.
 
 ### List/Discovery Tools
 - **`list_stores`** - List all File Search Stores

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -136,7 +136,7 @@ func NewServer(client GeminiClient, enabledTools []string) *server.MCPServer {
 	// Tool: import_file_to_store
 	if isToolEnabled("import_file_to_store") || isToolEnabled("all") {
 		s.AddTool(mcp.NewTool("import_file_to_store",
-			mcp.WithDescription("Import a file from the Files API into a File Search Store."),
+			mcp.WithDescription("Import a file from the Files API into a File Search Store. Note: This does not preserve the original display name of the file."),
 			mcp.WithString("file_name", mcp.Required(), mcp.Description("The resource name or display name of the file to import.")),
 			mcp.WithString("store_name", mcp.Required(), mcp.Description("The resource name or display name of the store to import into.")),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
Currently, the API doesn't appear to accept any values other than these and the python library strips anything other than them from the incoming config dict:

`fileName` *string*
Required. The name of the File to import. Example: files/abc-123

`customMetadata[]` *object ([CustomMetadata](https://ai.google.dev/api/file-search/documents#CustomMetadata))*
Custom metadata to be associated with the file.

`chunkingConfig` *object (ChunkingConfig)*
Optional. Config for telling the service how to chunk the file. If not provided, the service will use default parameters.

https://ai.google.dev/api/file-search/file-search-stores#method:-filesearchstores.importfile