### PR TITLE
feat: allow batch uploads

### DIFF
--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"context"
+	"sync"
+)
+
+// BatchOptions provides configuration for batch processing.
+type BatchOptions struct {
+	Concurrency int // Number of parallel operations (default: 5)
+	Quiet       bool
+	OnProgress  func(current, total int, file string, err error)
+}
+
+// BatchResult holds the outcome of a batch processing operation.
+type BatchResult struct {
+	Succeeded []string
+	Failed    map[string]error
+	Total     int
+}
+
+// processBatch processes a slice of files concurrently.
+// It takes a context, a list of files, a processor function for each file, and batch options.
+// The processor function should return an error if the processing of a single file fails.
+// It returns a BatchResult summarizing the operation.
+func processBatch(ctx context.Context, files []string, processor func(ctx context.Context, file string) error, opts *BatchOptions) *BatchResult {
+	result := &BatchResult{
+		Succeeded: make([]string, 0),
+		Failed:    make(map[string]error),
+		Total:     len(files),
+	}
+
+	if len(files) == 0 {
+		return result
+	}
+
+	if opts == nil {
+		opts = &BatchOptions{}
+	}
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = 5 // Default concurrency
+	}
+
+	var (
+		wg          sync.WaitGroup
+		mu          sync.Mutex // Protects result, fileIdx, and progress updates
+		inProgress  = make(chan struct{}, opts.Concurrency)
+		processedMu sync.Mutex // Protects processedCount
+		processedCount int
+	)
+
+	for _, file := range files {
+		inProgress <- struct{}{} // Acquire a slot
+
+		wg.Add(1)
+		go func(f string) {
+			defer func() {
+				<-inProgress // Release the slot
+				wg.Done()
+			}()
+
+			err := processor(ctx, f)
+
+			mu.Lock()
+			processedMu.Lock()
+			processedCount++
+			current := processedCount
+			mu.Unlock()
+			processedMu.Unlock()
+			
+			if opts.OnProgress != nil && !opts.Quiet {
+				opts.OnProgress(current, result.Total, f, err)
+			}
+
+			mu.Lock()
+			if err != nil {
+				result.Failed[f] = err
+			} else {
+				result.Succeeded = append(result.Succeeded, f)
+			}
+			mu.Unlock()
+		}(file)
+	}
+
+	wg.Wait()
+	return result
+}

--- a/cmd/batch_test.go
+++ b/cmd/batch_test.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestProcessBatch(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		files       []string
+		concurrency int
+		processor   func(ctx context.Context, file string) error
+		wantSucceed int
+		wantFailed  int
+		wantError   bool
+	}{
+		{
+			name:        "empty file list",
+			files:       []string{},
+			concurrency: 1,
+			processor:   func(ctx context.Context, file string) error { return nil },
+			wantSucceed: 0,
+			wantFailed:  0,
+			wantError:   false,
+		},
+		{
+			name:        "single file success",
+			files:       []string{"file1.txt"},
+			concurrency: 1,
+			processor:   func(ctx context.Context, file string) error { return nil },
+			wantSucceed: 1,
+			wantFailed:  0,
+			wantError:   false,
+		},
+		{
+			name:        "single file failure",
+			files:       []string{"file1.txt"},
+			concurrency: 1,
+			processor:   func(ctx context.Context, file string) error { return fmt.Errorf("failed") },
+			wantSucceed: 0,
+			wantFailed:  1,
+			wantError:   true,
+		},
+		{
+			name:        "multiple files all success",
+			files:       []string{"file1.txt", "file2.txt", "file3.txt"},
+			concurrency: 2,
+			processor:   func(ctx context.Context, file string) error { return nil },
+			wantSucceed: 3,
+			wantFailed:  0,
+			wantError:   false,
+		},
+		{
+			name:        "multiple files all failure",
+			files:       []string{"file1.txt", "file2.txt", "file3.txt"},
+			concurrency: 2,
+			processor:   func(ctx context.Context, file string) error { return fmt.Errorf("failed: %s", file) },
+			wantSucceed: 0,
+			wantFailed:  3,
+			wantError:   true,
+		},
+		{
+			name:        "multiple files mixed success and failure",
+			files:       []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt"},
+			concurrency: 2,
+			processor: func(ctx context.Context, file string) error {
+				if file == "file2.txt" || file == "file4.txt" {
+					return fmt.Errorf("failed: %s", file)
+				}
+				return nil
+			},
+			wantSucceed: 2,
+			wantFailed:  2,
+			wantError:   true,
+		},
+		{
+			name:        "high concurrency",
+			files:       []string{"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10"},
+			concurrency: 10,
+			processor:   func(ctx context.Context, file string) error { time.Sleep(10 * time.Millisecond); return nil },
+			wantSucceed: 10,
+			wantFailed:  0,
+			wantError:   false,
+		},
+		{
+			name:        "low concurrency",
+			files:       []string{"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10"},
+			concurrency: 1,
+			processor:   func(ctx context.Context, file string) error { time.Sleep(10 * time.Millisecond); return nil },
+			wantSucceed: 10,
+			wantFailed:  0,
+			wantError:   false,
+		},
+		{
+			name:        "concurrency boundary - exact number of files",
+			files:       []string{"f1", "f2", "f3", "f4", "f5"},
+			concurrency: 5,
+			processor:   func(ctx context.Context, file string) error { return nil },
+			wantSucceed: 5,
+			wantFailed:  0,
+			wantError:   false,
+		},
+		{
+			name:        "concurrency boundary - more concurrency than files",
+			files:       []string{"f1", "f2", "f3"},
+			concurrency: 5,
+			processor:   func(ctx context.Context, file string) error { return nil },
+			wantSucceed: 3,
+			wantFailed:  0,
+			wantError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var progressCalls int32
+			opts := &BatchOptions{
+				Concurrency: tt.concurrency,
+				Quiet:       false,
+				OnProgress: func(current, total int, file string, err error) {
+					atomic.AddInt32(&progressCalls, 1)
+					if current <= 0 || current > total || total != len(tt.files) {
+						t.Errorf("OnProgress called with invalid current/total: %d/%d for file %s", current, total, file)
+					}
+				},
+			}
+
+			result := processBatch(ctx, tt.files, tt.processor, opts)
+
+			if result.Total != len(tt.files) {
+				t.Errorf("processBatch() Total = %v, want %v", result.Total, len(tt.files))
+			}
+			if len(result.Succeeded) != tt.wantSucceed {
+				t.Errorf("processBatch() Succeeded = %v, want %v", len(result.Succeeded), tt.wantSucceed)
+			}
+			if len(result.Failed) != tt.wantFailed {
+				t.Errorf("processBatch() Failed = %v, want %v", len(result.Failed), tt.wantFailed)
+			}
+
+			// Check if OnProgress was called for each file if not quiet
+			if !opts.Quiet && len(tt.files) > 0 {
+				if int(atomic.LoadInt32(&progressCalls)) != len(tt.files) {
+					t.Errorf("OnProgress callback count mismatch: got %d, want %d", atomic.LoadInt32(&progressCalls), len(tt.files))
+				}
+			}
+
+			// Verify contents of Succeeded and Failed maps/slices
+			var sortedSucceeded []string
+			for _, s := range result.Succeeded {
+				sortedSucceeded = append(sortedSucceeded, s)
+			}
+			sort.Strings(sortedSucceeded)
+
+			var expectedSucceeded []string
+			for _, f := range tt.files {
+				if _, ok := tt.processor(ctx, f).(error); !ok {
+					expectedSucceeded = append(expectedSucceeded, f)
+				}
+			}
+			sort.Strings(expectedSucceeded)
+
+			if fmt.Sprintf("%v", sortedSucceeded) != fmt.Sprintf("%v", expectedSucceeded) {
+				t.Errorf("processBatch() Succeeded files = %v, want %v", sortedSucceeded, expectedSucceeded)
+			}
+
+			var sortedFailed []string
+			for f := range result.Failed {
+				sortedFailed = append(sortedFailed, f)
+			}
+			sort.Strings(sortedFailed)
+
+			var expectedFailed []string
+			for _, f := range tt.files {
+				if tt.processor(ctx, f) != nil {
+					expectedFailed = append(expectedFailed, f)
+				}
+			}
+			sort.Strings(expectedFailed)
+
+			if fmt.Sprintf("%v", sortedFailed) != fmt.Sprintf("%v", expectedFailed) {
+				t.Errorf("processBatch() Failed files = %v, want %v", sortedFailed, expectedFailed)
+			}
+
+		})
+	}
+}
+
+func TestProcessBatch_ContextCancellation(t *testing.T) {
+	files := []string{"f1", "f2", "f3", "f4", "f5"}
+	slowProcessor := func(ctx context.Context, file string) error {
+		select {
+		case <-time.After(100 * time.Millisecond):
+			// Simulate work
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		return nil
+	}
+
+	t.Run("cancellation stops pending tasks", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var processedCount atomic.Int32
+		opts := &BatchOptions{
+			Concurrency: 1, // Ensure sequential processing for predictable cancellation
+			OnProgress: func(current, total int, file string, err error) {
+				processedCount.Add(1)
+				if current == 2 { // Cancel after the second file starts processing
+					cancel()
+				}
+			},
+		}
+
+		result := processBatch(ctx, files, slowProcessor, opts)
+
+		// Expect f1 and f2 to be processed (f2 might be cancelled mid-way, or just before returning)
+		// It's hard to precisely predict how many will *succeed* when cancelled
+		// but we expect not all to succeed.
+		if len(result.Succeeded)+len(result.Failed) != int(processedCount.Load()) {
+			t.Errorf("Expected total processed files %d, got %d", processedCount.Load(), len(result.Succeeded)+len(result.Failed))
+		}
+		if len(result.Succeeded) == len(files) {
+			t.Errorf("Expected some files to be cancelled, but all succeeded")
+		}
+	})
+
+	t.Run("no cancellation finishes all tasks", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel() // Ensure context is cancelled eventually, but not prematurely
+
+		var processedCount int32
+		opts := &BatchOptions{
+			Concurrency: 1,
+			OnProgress: func(current, total int, file string, err error) {
+				atomic.AddInt32(&processedCount, 1)
+			},
+		}
+
+		result := processBatch(ctx, files, slowProcessor, opts)
+
+		if len(result.Succeeded) != len(files) {
+			t.Errorf("Expected all files to succeed, but got %d succeeded", len(result.Succeeded))
+		}
+		if int(processedCount) != len(files) {
+			t.Errorf("Expected OnProgress to be called for all files, but got %d calls", processedCount)
+		}
+	})
+}

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -112,10 +112,11 @@ func init() {
 	var uploadChunkSize int
 	var uploadChunkOverlap int
 	var uploadMetadata []string
+	var uploadConcurrency int
 	uploadCmd := &cobra.Command{
-		Use:   "upload [path]",
-		Short: "Upload and import a file",
-		Args:  cobra.ExactArgs(1),
+		Use:   "upload [path]...",
+		Short: "Upload and import files",
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			client, err := getClient(ctx)
@@ -124,6 +125,10 @@ func init() {
 			}
 			defer client.Close()
 
+			if len(args) > 1 && uploadDisplayName != "" {
+				return fmt.Errorf("cannot use --name with multiple files")
+			}
+
 			// Parse metadata from key=value strings
 			metadataMap := make(map[string]string)
 			for _, meta := range uploadMetadata {
@@ -131,12 +136,6 @@ func init() {
 				if len(parts) == 2 {
 					metadataMap[parts[0]] = parts[1]
 				}
-			}
-
-			// Auto-set display name from filename if not provided
-			displayName := uploadDisplayName
-			if displayName == "" {
-				displayName = filepath.Base(args[0])
 			}
 
 			// Resolve store name to ID if --store was used
@@ -148,31 +147,88 @@ func init() {
 				}
 			}
 
-			opts := &gemini.UploadFileOptions{
-				StoreName:      storeID,
-				DisplayName:    displayName,
-				MIMEType:       uploadMimeType,
-				MaxChunkTokens: uploadChunkSize,
-				ChunkOverlap:   uploadChunkOverlap,
-				Metadata:       metadataMap,
-				Quiet:          quiet,
-			}
+			// Define the processor function for a single file
+			processor := func(ctx context.Context, path string) error {
+				displayName := uploadDisplayName
+				if displayName == "" {
+					displayName = filepath.Base(path)
+				}
 
-			file, err := client.UploadFile(ctx, args[0], opts)
-			if err != nil {
+				if !quiet {
+					fmt.Printf("[+] Starting upload: %s\n", displayName)
+				}
+
+				opts := &gemini.UploadFileOptions{
+					StoreName:      storeID,
+					DisplayName:    displayName,
+					MIMEType:       uploadMimeType,
+					MaxChunkTokens: uploadChunkSize,
+					ChunkOverlap:   uploadChunkOverlap,
+					Metadata:       metadataMap,
+					Quiet:          true, // Force quiet for inner operation to prevent output interleaving
+				}
+				_, err := client.UploadFile(ctx, path, opts)
 				return err
 			}
 
-			if outputFormat == "json" {
-				if file != nil {
-					return printOutput(file, "json")
+			// Define the progress callback
+			onProgress := func(current, total int, file string, err error) {
+				if err != nil {
+					fmt.Printf("[%d/%d] ✗ Failed: %s (%v)\n", current, total, filepath.Base(file), err)
+				} else {
+					fmt.Printf("[%d/%d] ✓ Finished: %s\n", current, total, filepath.Base(file))
 				}
-				return printOutput(map[string]string{"status": "uploaded_and_indexed"}, "json")
 			}
 
-			if file != nil {
-				fmt.Printf("Uploaded file: %s (URI: %s)\n", file.DisplayName, file.URI)
+			// Process files using the batch processor
+			batchResult := processBatch(ctx, args, processor, &BatchOptions{
+				Concurrency: uploadConcurrency,
+				Quiet:       quiet,
+				OnProgress:  onProgress,
+			})
+
+			// Print summary
+			if !quiet {
+				if len(args) > 1 { // Only print summary if multiple files were processed
+					fmt.Printf("\n\nSummary:\n")
+					fmt.Printf("  ✓ Succeeded: %d\n", len(batchResult.Succeeded))
+					fmt.Printf("  ✗ Failed: %d\n", len(batchResult.Failed))
+				}
 			}
+
+			if outputFormat == "json" {
+				// For JSON, aggregate results
+				jsonResult := make(map[string]interface{})
+				jsonResult["total"] = batchResult.Total
+				jsonResult["succeeded"] = len(batchResult.Succeeded)
+				jsonResult["failed"] = len(batchResult.Failed)
+
+				filesSummary := make([]map[string]interface{}, 0, batchResult.Total)
+				for _, f := range batchResult.Succeeded {
+					filesSummary = append(filesSummary, map[string]interface{}{"file": f, "status": "success"})
+				}
+				for f, err := range batchResult.Failed {
+					filesSummary = append(filesSummary, map[string]interface{}{"file": f, "status": "failed", "error": err.Error()})
+				}
+				jsonResult["files"] = filesSummary
+				return printOutput(jsonResult, "json")
+
+			} else { // Text output
+				if len(batchResult.Failed) > 0 {
+					if !quiet {
+						fmt.Printf("\nFailed files:\n")
+						for f, err := range batchResult.Failed {
+							fmt.Printf("  - %s: %v\n", f, err)
+						}
+					}
+					return fmt.Errorf("some files failed to upload")
+				}
+				if !quiet && len(args) == 1 && len(batchResult.Succeeded) == 1 {
+					// If single file and succeeded, print success message
+					fmt.Printf("Uploaded file: %s\n", batchResult.Succeeded[0])
+				}
+			}
+
 			return nil
 		},
 	}
@@ -183,6 +239,7 @@ func init() {
 	uploadCmd.Flags().IntVar(&uploadChunkSize, "chunk-size", 0, "Max tokens per chunk (for store uploads)")
 	uploadCmd.Flags().IntVar(&uploadChunkOverlap, "chunk-overlap", 0, "Overlap tokens between chunks (for store uploads)")
 	uploadCmd.Flags().StringArrayVar(&uploadMetadata, "metadata", []string{}, "Custom metadata as key=value (repeatable, for store uploads)")
+	uploadCmd.Flags().IntVar(&uploadConcurrency, "concurrency", 5, "Number of parallel uploads")
 	uploadCmd.RegisterFlagCompletionFunc("store", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return getCompleter().GetStoreNames(), cobra.ShellCompDirectiveNoFileComp
 	})

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -61,7 +61,18 @@ func (c *Client) ListStores(ctx context.Context) ([]*genai.FileSearchStore, erro
 	if err != nil {
 		return nil, err
 	}
-	return resp.Items, nil
+
+	var stores []*genai.FileSearchStore
+	stores = append(stores, resp.Items...)
+
+	for resp.NextPageToken != "" {
+		resp, err = resp.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+		stores = append(stores, resp.Items...)
+	}
+	return stores, nil
 }
 
 func (c *Client) ListModels(ctx context.Context) ([]*genai.Model, error) {
@@ -92,12 +103,12 @@ func (c *Client) ResolveStoreName(ctx context.Context, nameOrID string) (string,
 	}
 
 	// Otherwise, search for display name
-	resp, err := c.client.FileSearchStores.List(ctx, nil)
+	stores, err := c.ListStores(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	for _, s := range resp.Items {
+	for _, s := range stores {
 		if s.DisplayName == nameOrID {
 			return s.Name, nil
 		}
@@ -115,12 +126,12 @@ func (c *Client) ResolveFileName(ctx context.Context, nameOrID string) (string, 
 	}
 
 	// Otherwise, search for display name
-	resp, err := c.client.Files.List(ctx, nil)
+	files, err := c.ListFiles(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	for _, f := range resp.Items {
+	for _, f := range files {
 		if f.DisplayName == nameOrID {
 			return f.Name, nil
 		}
@@ -145,12 +156,12 @@ func (c *Client) ResolveDocumentName(ctx context.Context, storeNameOrID, docName
 	}
 
 	// Search for document by display name
-	resp, err := c.client.FileSearchStores.Documents.List(ctx, storeID, nil)
+	docs, err := c.ListDocuments(ctx, storeID)
 	if err != nil {
 		return "", err
 	}
 
-	for _, doc := range resp.Items {
+	for _, doc := range docs {
 		if doc.DisplayName == docNameOrID {
 			return doc.Name, nil
 		}
@@ -161,13 +172,13 @@ func (c *Client) ResolveDocumentName(ctx context.Context, storeNameOrID, docName
 
 // GetStoreNames returns a list of all store display names for completion.
 func (c *Client) GetStoreNames(ctx context.Context) ([]string, error) {
-	resp, err := c.client.FileSearchStores.List(ctx, nil)
+	stores, err := c.ListStores(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	names := make([]string, 0, len(resp.Items))
-	for _, s := range resp.Items {
+	names := make([]string, 0, len(stores))
+	for _, s := range stores {
 		names = append(names, s.DisplayName)
 	}
 	return names, nil
@@ -175,13 +186,13 @@ func (c *Client) GetStoreNames(ctx context.Context) ([]string, error) {
 
 // GetFileNames returns a list of all file display names for completion.
 func (c *Client) GetFileNames(ctx context.Context) ([]string, error) {
-	resp, err := c.client.Files.List(ctx, nil)
+	files, err := c.ListFiles(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	names := make([]string, 0, len(resp.Items))
-	for _, f := range resp.Items {
+	names := make([]string, 0, len(files))
+	for _, f := range files {
 		names = append(names, f.DisplayName)
 	}
 	return names, nil
@@ -189,13 +200,13 @@ func (c *Client) GetFileNames(ctx context.Context) ([]string, error) {
 
 // GetDocumentNames returns a list of all document display names in a store for completion.
 func (c *Client) GetDocumentNames(ctx context.Context, storeID string) ([]string, error) {
-	resp, err := c.client.FileSearchStores.Documents.List(ctx, storeID, nil)
+	docs, err := c.ListDocuments(ctx, storeID)
 	if err != nil {
 		return nil, err
 	}
 
-	names := make([]string, 0, len(resp.Items))
-	for _, doc := range resp.Items {
+	names := make([]string, 0, len(docs))
+	for _, doc := range docs {
 		names = append(names, doc.DisplayName)
 	}
 	return names, nil
@@ -377,7 +388,18 @@ func (c *Client) ListFiles(ctx context.Context) ([]*genai.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return resp.Items, nil
+
+	var files []*genai.File
+	files = append(files, resp.Items...)
+
+	for resp.NextPageToken != "" {
+		resp, err = resp.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, resp.Items...)
+	}
+	return files, nil
 }
 
 func (c *Client) GetFile(ctx context.Context, name string) (*genai.File, error) {
@@ -389,7 +411,18 @@ func (c *Client) ListDocuments(ctx context.Context, storeName string) ([]*genai.
 	if err != nil {
 		return nil, err
 	}
-	return resp.Items, nil
+
+	var docs []*genai.Document
+	docs = append(docs, resp.Items...)
+
+	for resp.NextPageToken != "" {
+		resp, err = resp.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+		docs = append(docs, resp.Items...)
+	}
+	return docs, nil
 }
 
 func (c *Client) GetDocument(ctx context.Context, name string) (*genai.Document, error) {


### PR DESCRIPTION
Some list methods were not paginating and stopping at 10 results. The grounding results don't provide page numbers so breaking large documents into chapters and uploading them in batches should help with narrowing down citation locations.

fix: ensure all list methods paginate properly